### PR TITLE
Change the runner to remove fiss dependency.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,14 +5,14 @@ stages:
 
 before_script:
   - date && date -u
-  - apt-get update && apt-get install -y python3.7 python3.7-dev python3-pip python-pip virtualenv git apt-transport-https ca-certificates gnupg curl
+  - apt-get update && apt-get install -y python3.8 python3.8-dev python3-pip python-pip virtualenv git apt-transport-https ca-certificates gnupg curl
   - echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y
 
 unit_tests:
   stage: test
   script:
     - source environment
-    - virtualenv -p python3.7 venv && . venv/bin/activate
+    - virtualenv -p python3.8 venv && . venv/bin/activate
     - git clone https://github.com/DataBiosphere/terra-notebook-utils.git  && cd terra-notebook-utils && python setup.py install
     - cd .. && pip install -r requirements.txt
     - test/test_basic_submission.py
@@ -22,7 +22,7 @@ scheduled_tests:
     - schedules
   script:
     - source environment
-    - virtualenv -p python3.7 venv && . venv/bin/activate
+    - virtualenv -p python3.8 venv && . venv/bin/activate
     - git clone https://github.com/DataBiosphere/terra-notebook-utils.git  && cd terra-notebook-utils && python setup.py install
     - cd .. && pip install -r requirements.txt
     - test/test_basic_submission.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,14 +5,14 @@ stages:
 
 before_script:
   - date && date -u
-  - apt-get update && apt-get install -y python3.8 python3.8-dev python3-pip python-pip virtualenv git apt-transport-https ca-certificates gnupg curl
+  - apt-get update && apt-get install -y python3.7 python3.7-dev python3-pip python-pip virtualenv git apt-transport-https ca-certificates gnupg curl
   - echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y
 
 unit_tests:
   stage: test
   script:
     - source environment
-    - virtualenv -p python3.8 venv && . venv/bin/activate
+    - virtualenv -p python3.7 venv && . venv/bin/activate
     - git clone https://github.com/DataBiosphere/terra-notebook-utils.git  && cd terra-notebook-utils && python setup.py install
     - cd .. && pip install -r requirements.txt
     - test/test_basic_submission.py
@@ -22,7 +22,7 @@ scheduled_tests:
     - schedules
   script:
     - source environment
-    - virtualenv -p python3.8 venv && . venv/bin/activate
+    - virtualenv -p python3.7 venv && . venv/bin/activate
     - git clone https://github.com/DataBiosphere/terra-notebook-utils.git  && cd terra-notebook-utils && python setup.py install
     - cd .. && pip install -r requirements.txt
     - test/test_basic_submission.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 google-cloud-secret-manager==0.2.0
 google-cloud-storage==1.27.0
 gen3==2.2.3
-firecloud==0.16.26
 requests
 terra-notebook-utils==0.0.2

--- a/test/test_basic_submission.py
+++ b/test/test_basic_submission.py
@@ -11,7 +11,6 @@ import requests
 import warnings
 import google.cloud.storage
 
-from firecloud import fiss
 from gen3.submission import Gen3Submission
 from gen3.auth import Gen3Auth
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -4,12 +4,10 @@ import requests
 import hashlib
 import functools
 import time
-import subprocess
 
 from typing import List, Set
 from requests.exceptions import HTTPError
 
-from firecloud import fiss
 from terra_notebook_utils import gs, GS_SCHEMA
 
 GEN3_ENDPOINTS = {


### PR DESCRIPTION
We're not using the API directly anymore anyway, and are just calling the requests directly.  Address: https://biodata-integration-tests.net/databiosphere/bdcat-integration-tests/-/jobs/643