### PR TITLE
Check status of workflow differently.  Increase timeout.

### DIFF
--- a/test/test_basic_submission.py
+++ b/test/test_basic_submission.py
@@ -169,7 +169,7 @@ class TestGen3DataAccess(unittest.TestCase):
 
         with self.subTest('Check on the import static pfb job status.'):
             response = pfb_job_status_in_terra(workspace=workspace_name, job_id=response['jobId'])
-            # this should take less than 60 seconds
+            # this should take < 60 seconds
             while response['status'] in ['Translating', 'ReadyForUpsert', 'Upserting']:
                 time.sleep(2)
                 response = pfb_job_status_in_terra(workspace=workspace_name, job_id=response['jobId'])


### PR DESCRIPTION
When checking the status of a workflow, there are two status fields:

```
{
    "status": "Done",
    "workflows": [
        {
            "inputResolutions": [
                {
                    "inputName": "ga4ghMd5.inputFile",
                    "value": "drs://dg.712C/fa640b0e-9779-452f-99a6-16d833d15bd0"
                }
            ],
            "messages": [
                "ErrorReport(rawls,http error calling uri https://us-central1-broad-dsde-alpha.cloudfunctions.net/martha_v2,Some(502 Bad Gateway),List(),List(),None)"
            ],
            "status": "Failed",
            "statusLastChangedDate": "2020-09-03T17:52:58.509Z",
            "workflowEntity": {
                "entityType": "data_access_test_drs_uris",
                "entityName": "dg.712C_fa640b0e-9779-452f-99a6-16d833d15bd0"
            }
        }
    ]
}
```

This test was erroneously only checking the first.  This PR changes the test to now wait until `response["status"] == "Done"` and then checks to verify that `response["workflows"][0]["status"] == "Succeeded"`.  I've also increased the timeout from 10 to 20 minutes.