### PR TITLE
Add debug info.

### DIFF
--- a/test/test_basic_submission.py
+++ b/test/test_basic_submission.py
@@ -173,7 +173,9 @@ class TestGen3DataAccess(unittest.TestCase):
             while response['status'] in ['Translating', 'ReadyForUpsert', 'Upserting']:
                 time.sleep(2)
                 response = pfb_job_status_in_terra(workspace=workspace_name, job_id=response['jobId'])
-            self.assertTrue(response['status'] == 'Done')
+            self.assertTrue(response['status'] == 'Done',
+                            msg=f'Expecting status: "Done" but got "{response["status"]}".\n'
+                                f'Full response: {json.dumps(response, indent=4)}')
 
         with self.subTest('Delete the terra workspace.'):
             response = delete_terra_workspace(workspace=workspace_name)


### PR DESCRIPTION
A recent failure only yielded:

```
FAIL: test_pfb_handoff_from_gen3_to_terra (__main__.TestGen3DataAccess) [Check on the import static pfb job status.]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_basic_submission.py", line 176, in test_pfb_handoff_from_gen3_to_terra
    self.assertTrue(response['status'] == 'Done')
AssertionError: False is not true
----------------------------------------------------------------------
Ran 3 tests in 430.555s
```

Now yields something like:

```
E           AssertionError: False is not true : Expecting status: "Done" but got "Failure".
E           Full response: {
E               "jobId": "0db1a2ff-7c1e-431e-83a0-5acf169d79cb",
E               "status": "Failure"
E           }
```

I tested this by running a successful job and then hardcoding the status as "Failure", so in theory, according to the swagger API, there might be a "message" explaining things: https://api.firecloud.org/#/Entities/importPFBStatus