### PR TITLE
Add MD5SUM_TEST_TIMEOUT to config md5sum tests.

### DIFF
--- a/test/test_basic_submission.py
+++ b/test/test_basic_submission.py
@@ -141,7 +141,7 @@ class TestGen3DataAccess(unittest.TestCase):
 
         # md5sum should run for about 4 minutes, but may take far longer(?); give a generous timeout
         # also configurable manually via MD5SUM_TEST_TIMEOUT if held in a pending state
-        timeout = twenty_minutes = int(os.environ.get('MD5SUM_TEST_TIMEOUT', None)) or 20 * 60
+        timeout = twenty_minutes = int(os.environ.get('MD5SUM_TEST_TIMEOUT', 20 * 60))
         while status != 'Done':
             response = check_workflow_status(submission_id=submission_id)
             time.sleep(20)

--- a/test/test_basic_submission.py
+++ b/test/test_basic_submission.py
@@ -140,7 +140,8 @@ class TestGen3DataAccess(unittest.TestCase):
         submission_id = response['submissionId']
 
         # md5sum should run for about 4 minutes, but may take far longer(?); give a generous timeout
-        timeout = twenty_minutes = 20 * 60
+        # also configurable manually via MD5SUM_TEST_TIMEOUT if held in a pending state
+        timeout = twenty_minutes = int(os.environ.get('MD5SUM_TEST_TIMEOUT', None)) or 20 * 60
         while status != 'Done':
             response = check_workflow_status(submission_id=submission_id)
             time.sleep(20)


### PR DESCRIPTION
This should allow the md5sum test to be configured to run longer for debugging purposes if it's stuck in a pending state (which gives no explicit error, just that the state didn't match).
