### PR TITLE
Add a better error message.

### DIFF
--- a/test/test_basic_submission.py
+++ b/test/test_basic_submission.py
@@ -162,7 +162,10 @@ class TestGen3DataAccess(unittest.TestCase):
 
         with self.subTest('Delete the terra workspace.'):
             response = delete_terra_workspace(workspace=workspace_name)
-            self.assertTrue(response.status_code == 202)
+            if not response.ok:
+                raise RuntimeError(f'Could not delete the workspace "{workspace_name}": [{response.status_code}] {response}')
+            if response.status_code != 202:
+                logger.critical(f'Response {response.status_code} has changed: {response}')
             response = delete_terra_workspace(workspace=workspace_name)
             self.assertTrue(response.status_code == 404)
 


### PR DESCRIPTION
Because of: https://biodata-integration-tests.net/databiosphere/bdcat-integration-tests/-/jobs/72965

```
======================================================================
FAIL: test_pfb_handoff_from_gen3_to_terra (__main__.TestGen3DataAccess) [Delete the terra workspace.]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_basic_submission.py", line 165, in test_pfb_handoff_from_gen3_to_terra
    self.assertTrue(response.status_code == 202)
AssertionError: False is not true
----------------------------------------------------------------------
```