### PR TITLE
Update tnu workspace config method.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ staging:
     - ./venv/bin/python -m pip install --no-cache-dir -r requirements.txt
     - make lint
     - export PATH="$PATH:/opt/webdriver"
-    - unset GOOGLE_APPLICATION_CREDENTIALS; export GOOGLE_PROJECT_NAME=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests; export GOOGLE_PROJECT_ID=drs-billing-project
+    - export GOOGLE_PROJECT_NAME=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests; export GOOGLE_PROJECT_ID=drs-billing-project
     - BDCAT_STAGE=staging TERRA_DEPLOYMENT_ENV=alpha test/test_basic_submission.py
   only:
     - master
@@ -42,7 +42,7 @@ version_check:
     - virtualenv -p python3.8 venv && . venv/bin/activate
     - ./venv/bin/python -m pip install --no-cache-dir -r requirements.txt
     - make lint
-    - unset GOOGLE_APPLICATION_CREDENTIALS; export GOOGLE_PROJECT_NAME=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests; export GOOGLE_PROJECT_ID=drs-billing-project
+    - export GOOGLE_PROJECT_NAME=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests; export GOOGLE_PROJECT_ID=drs-billing-project
     - BDCAT_STAGE=staging TERRA_DEPLOYMENT_ENV=alpha test/test_version_check.py
   only:
     - master
@@ -87,7 +87,7 @@ dev-staging:
     - ./venv/bin/python -m pip install --no-cache-dir -r requirements.txt
     - make lint
     - export PATH="$PATH:/opt/webdriver"
-    - unset GOOGLE_APPLICATION_CREDENTIALS; export GOOGLE_PROJECT_NAME=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests; export GOOGLE_PROJECT_ID=drs-billing-project
+    - export GOOGLE_PROJECT_NAME=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests; export GOOGLE_PROJECT_ID=drs-billing-project
     - BDCAT_STAGE=staging TERRA_DEPLOYMENT_ENV=alpha test/test_basic_submission.py
   except:
     - schedules

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,7 @@ staging:
     - ./venv/bin/python -m pip install --no-cache-dir -r requirements.txt
     - make lint
     - export PATH="$PATH:/opt/webdriver"
+    - unset GOOGLE_APPLICATION_CREDENTIALS; export GOOGLE_PROJECT_NAME=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests; export GOOGLE_PROJECT_ID=drs-billing-project
     - BDCAT_STAGE=staging TERRA_DEPLOYMENT_ENV=alpha test/test_basic_submission.py
   only:
     - master
@@ -41,6 +42,7 @@ version_check:
     - virtualenv -p python3.8 venv && . venv/bin/activate
     - ./venv/bin/python -m pip install --no-cache-dir -r requirements.txt
     - make lint
+    - unset GOOGLE_APPLICATION_CREDENTIALS; export GOOGLE_PROJECT_NAME=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests; export GOOGLE_PROJECT_ID=drs-billing-project
     - BDCAT_STAGE=staging TERRA_DEPLOYMENT_ENV=alpha test/test_version_check.py
   only:
     - master
@@ -85,6 +87,7 @@ dev-staging:
     - ./venv/bin/python -m pip install --no-cache-dir -r requirements.txt
     - make lint
     - export PATH="$PATH:/opt/webdriver"
+    - unset GOOGLE_APPLICATION_CREDENTIALS; export GOOGLE_PROJECT_NAME=firecloud-cgl; export WORKSPACE_NAME=terra-notebook-utils-tests; export GOOGLE_PROJECT_ID=drs-billing-project
     - BDCAT_STAGE=staging TERRA_DEPLOYMENT_ENV=alpha test/test_basic_submission.py
   except:
     - schedules

--- a/test/test_basic_submission.py
+++ b/test/test_basic_submission.py
@@ -233,15 +233,15 @@ class TestGen3DataAccess(unittest.TestCase):
                 time.sleep(2)
                 timeout -= 2
 
-    @staging_only
-    def test_import_drs_from_gen3(self):
-        # file is ~1gb, so only download the first byte to check for access
-        import_drs_from_gen3('drs://dg.712C/95dc0845-d895-489f-aaf8-583a676037f7')
-
-        # TODO: Investigate the following:
-        # the following file is 5b, but we get a "Not enough segments" Error, so there may be problems with small files:
-        # <p class="body">Error Message:</p>\n          <p class="introduction">Not enough segments</p>\n          \n          <div>\n            \n            <p class="body">Please try again!</p>
-        # import_drs_from_gen3('drs://dg.712C/b7a10338-6fb6-4201-adde-0ee933e069bc')
+    # @staging_only
+    # def test_import_drs_from_gen3(self):
+    #     # file is ~1gb, so only download the first byte to check for access
+    #     import_drs_from_gen3('drs://dg.712C/95dc0845-d895-489f-aaf8-583a676037f7')
+    #
+    #     # TODO: Investigate the following:
+    #     # the following file is 5b, but we get a "Not enough segments" Error, so there may be problems with small files:
+    #     # <p class="body">Error Message:</p>\n          <p class="introduction">Not enough segments</p>\n          \n          <div>\n            \n            <p class="body">Please try again!</p>
+    #     # import_drs_from_gen3('drs://dg.712C/b7a10338-6fb6-4201-adde-0ee933e069bc')
 
 
 if __name__ == "__main__":

--- a/test/test_basic_submission.py
+++ b/test/test_basic_submission.py
@@ -233,15 +233,15 @@ class TestGen3DataAccess(unittest.TestCase):
                 time.sleep(2)
                 timeout -= 2
 
-    # @staging_only
-    # def test_import_drs_from_gen3(self):
-    #     # file is ~1gb, so only download the first byte to check for access
-    #     import_drs_from_gen3('drs://dg.712C/95dc0845-d895-489f-aaf8-583a676037f7')
-    #
-    #     # TODO: Investigate the following:
-    #     # the following file is 5b, but we get a "Not enough segments" Error, so there may be problems with small files:
-    #     # <p class="body">Error Message:</p>\n          <p class="introduction">Not enough segments</p>\n          \n          <div>\n            \n            <p class="body">Please try again!</p>
-    #     # import_drs_from_gen3('drs://dg.712C/b7a10338-6fb6-4201-adde-0ee933e069bc')
+    @staging_only
+    def test_import_drs_from_gen3(self):
+        # file is ~1gb, so only download the first byte to check for access
+        import_drs_from_gen3('drs://dg.712C/95dc0845-d895-489f-aaf8-583a676037f7')
+
+        # TODO: Investigate the following:
+        # the following file is 5b, but we get a "Not enough segments" Error, so there may be problems with small files:
+        # <p class="body">Error Message:</p>\n          <p class="introduction">Not enough segments</p>\n          \n          <div>\n            \n            <p class="body">Please try again!</p>
+        # import_drs_from_gen3('drs://dg.712C/b7a10338-6fb6-4201-adde-0ee933e069bc')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This was done previously with the DRS head python API: https://github.com/DataBiosphere/bdcat-integration-tests/blob/master/test/test_basic_submission.py#L182

It looks like the python API no longer registers these workspace args, and needs them to be environment variables.

The error I was seeing was:

```
$ BDCAT_STAGE=staging TERRA_DEPLOYMENT_ENV=alpha test/test_basic_submission.py
2021-07-16 05:18:44::INFO  Enabling requester pays for your workspace. This will only take a few seconds...
2021-07-16 05:19:55::WARNING  Failed to init requester pays for workspace None/None.
2021-07-16 05:19:55::WARNING  You will not be able to access drs urls that interact with requester pays buckets.
```

https://biodata-integration-tests.net/databiosphere/bdcat-integration-tests/-/jobs/92414