### PR TITLE
Ensure pip freeze doesn't add bogus dependency.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ requirements:
 	virtualenv -p $(shell which python3) tmp-venv
 	./tmp-venv/bin/pip install -r requirements.txt.in
 	echo "# You should not edit this file directly.  Instead, you should edit requirements.txt.in." >| requirements.txt
-	./tmp-venv/bin/pip freeze >> requirements.txt
+	./tmp-venv/bin/pip freeze | sed -e 's/\<pkg-resources==0.0.0\>//g' >> requirements.txt
 	rm -rf tmp-venv
 
 .PHONY: lint requirements


### PR DESCRIPTION
When freezing requirements, pip freeze always erroneously adds `pkg-resources==0.0.0`, which I never seem to remember to remove so this automates that.