### PR TITLE
Rename tests to be more efficient.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,4 +56,5 @@ prod:
     - export PATH="$PATH:/opt/webdriver"
     - BDCAT_STAGE=prod test/test_basic_submission.py
   except:
+    - master
     - staging


### PR DESCRIPTION
This should parse things down a bit and also obviate the somehwat confusing dev-staging and dev-prod tests which are the same as prod and staging.