### PR TITLE
Use known DRS URI rather than polling ACL.

### DIFF
--- a/test/test_basic_submission.py
+++ b/test/test_basic_submission.py
@@ -238,26 +238,28 @@ class TestGen3DataAccess(unittest.TestCase):
 
     @staging_only
     def test_import_drs_from_gen3(self):
-        # TODO: There isn't a good way around these hard-coded public URIs right now.
-        public_uris = ['drs://dg.712C/60df2552-3d67-4f21-b637-5b53684fe444',
-                       'drs://dg.712C/a83118b2-8fdc-42de-9de2-5ddb27efb8eb',
-                       'drs://dg.712C/a84c1bcf-1975-402f-a973-ff7a307a2e90',
-                       'drs://dg.712C/b7a10338-6fb6-4201-adde-0ee933e069bc',
-                       'drs://dg.712C/2d9692bb-2050-4742-b7ae-42a83de6129e',
-                       'drs://dg.712C/39474412-fc6d-4dbc-81c2-176db2403130']
-
-        response = requests.get(
-            'https://staging.gen3.biodatacatalyst.nhlbi.nih.gov/index/index?'
-            'negate_params={"acl":["*","admin","topmed",'
-            '"phs000888", "phs000681", "phs001014", "phs001095", "phs001215", '
-            '"phs001544", "phs001395", "phs000169", "phs000636", "phs000820", '
-            '"phs000971", "phs000984", "phs000292", "phs000997", "phs000944", '
-            '"phs000304", "phs000209", "phs000538", "phs000353"]}')
-        restricted_records = [r['did'] for r in response.json()['records'] if r['did'] not in public_uris]
-        drs_uri = random.choice(restricted_records)
+        # TODO: This commented out section SHOULD be how we check for the ACL and DRS files we don't
+        #  have access to, but this is giving problems, so have to hardcode known restricted files.
+        # public_uris = ['drs://dg.712C/60df2552-3d67-4f21-b637-5b53684fe444',
+        #                'drs://dg.712C/a83118b2-8fdc-42de-9de2-5ddb27efb8eb',
+        #                'drs://dg.712C/a84c1bcf-1975-402f-a973-ff7a307a2e90',
+        #                'drs://dg.712C/b7a10338-6fb6-4201-adde-0ee933e069bc',
+        #                'drs://dg.712C/2d9692bb-2050-4742-b7ae-42a83de6129e',
+        #                'drs://dg.712C/39474412-fc6d-4dbc-81c2-176db2403130']
+        #
+        # response = requests.get(
+        #     'https://staging.gen3.biodatacatalyst.nhlbi.nih.gov/index/index?'
+        #     'negate_params={"acl":["*","admin","topmed",'
+        #     '"phs000888", "phs000681", "phs001014", "phs001095", "phs001215", '
+        #     '"phs001544", "phs001395", "phs000169", "phs000636", "phs000820", '
+        #     '"phs000971", "phs000984", "phs000292", "phs000997", "phs000944", '
+        #     '"phs000304", "phs000209", "phs000538", "phs000353"]}')
+        # restricted_records = [r['did'] for r in response.json()['records'] if r['did'] not in public_uris]
+        # drs_uri = random.choice(restricted_records)
 
         # first try to download the file and we should be denied
         # only downloads the first byte even if successful to keep it short
+        drs_uri = 'drs://dg.712C/01229405-6ce4-4ad7-aa04-19124afadebc'
         response = import_drs_with_direct_gen3_access_token(f'drs://{drs_uri}')
         self.assertEqual(response.status_code, 401)  # not a 403?
 

--- a/test/test_basic_submission.py
+++ b/test/test_basic_submission.py
@@ -259,8 +259,7 @@ class TestGen3DataAccess(unittest.TestCase):
 
         # first try to download the file and we should be denied
         # only downloads the first byte even if successful to keep it short
-        drs_uri = 'drs://dg.712C/01229405-6ce4-4ad7-aa04-19124afadebc'
-        response = import_drs_with_direct_gen3_access_token(f'drs://{drs_uri}')
+        response = import_drs_with_direct_gen3_access_token(f'drs://dg.712C/01229405-6ce4-4ad7-aa04-19124afadebc')
         self.assertEqual(response.status_code, 401)  # not a 403?
 
     # @staging_only

--- a/test/test_basic_submission.py
+++ b/test/test_basic_submission.py
@@ -259,7 +259,7 @@ class TestGen3DataAccess(unittest.TestCase):
 
         # first try to download the file and we should be denied
         # only downloads the first byte even if successful to keep it short
-        response = import_drs_with_direct_gen3_access_token(f'drs://dg.712C/01229405-6ce4-4ad7-aa04-19124afadebc')
+        response = import_drs_with_direct_gen3_access_token('drs://dg.712C/01229405-6ce4-4ad7-aa04-19124afadebc')
         self.assertEqual(response.status_code, 401)  # not a 403?
 
     # @staging_only


### PR DESCRIPTION
The DRS denial of access test has been intermittant because we poll the gen3 ACL of the user and select a random DRS URI we shouldn't have access to.  Polling a page returned gave:

```
401 drs://dg.712C/01229405-6ce4-4ad7-aa04-19124afadebc
401 drs://dg.712C/052f2f94-f4e7-4e71-a8fa-2ffb5460f263
401 drs://dg.712C/059c85e6-45a9-4e5d-9c6b-34047c2a4e7e
401 drs://dg.712C/153d86d8-4fb5-4f1e-be7c-e4257952fc9e
401 drs://dg.712C/26f3f9ae-324f-4c41-8a27-5684f2e6043c
401 drs://dg.712C/2d2567c4-f25c-4749-a96d-e2d9f1c5222b
200 drs://dg.712C/2d9692bb-2050-4742-b7ae-42a83de6129e
401 drs://dg.712C/38e55a5d-6f4b-429b-b3d4-6fec30b4ddc3
401 drs://dg.712C/393c8533-15b9-4141-88b8-d59098005d18
200 drs://dg.712C/39474412-fc6d-4dbc-81c2-176db2403130
401 drs://dg.712C/45770bfa-58ab-4ad0-a5ab-daeec5dd26f5
401 drs://dg.712C/5dbfc347-a14e-48dc-a58b-9194537326df
200 drs://dg.712C/60df2552-3d67-4f21-b637-5b53684fe444
401 drs://dg.712C/634ac55d-b55e-4d77-b72d-6019a6b7a797
401 drs://dg.712C/7dbf6b5d-cb62-423b-873b-a4b23f5fa49a
200 drs://dg.712C/a83118b2-8fdc-42de-9de2-5ddb27efb8eb
200 drs://dg.712C/a84c1bcf-1975-402f-a973-ff7a307a2e90
401 drs://dg.712C/b4b0d91b-4e2f-46fc-b763-40f7fe3c0b34
401 drs://dg.712C/b57f7232-c4eb-404b-94bd-7996da0a74cc
200 drs://dg.712C/b7a10338-6fb6-4201-adde-0ee933e069bc
401 drs://dg.712C/bb8bcfc0-c5de-4a2c-9e0e-c460076c8756
401 drs://dg.712C/bf7eee58-f58d-4de1-a623-3bd22416db1b
401 drs://dg.712C/c4589eb4-a753-4e1e-bb3c-b542e71d7dd5
401 drs://dg.712C/d76a87d3-7fe8-4e87-b921-71780b6dc321
401 drs://dg.712C/ecf3dcde-6780-4f90-92c3-282a6e31833c
401 drs://dg.712C/f39db4d3-3730-408f-8ade-e41dcae6db7d
```

Apparently some are always public and there isn't a good way around that that I know of, so this is commenting in a `#TODO` and hardcoding a known DRS URI that we shouldn't have access to.