### PR TITLE
Add a timeout to Gitlab tests to debug where tests fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ after_script:
 staging__basic_submission:
   <<: *staging_job
   script:
-    - /venv/bin/python test/test_basic_submission.py
+    - timeout -s SIGINT 115m /venv/bin/python test/test_basic_submission.py
 
 staging__version_check:
   <<: *staging_job
@@ -43,7 +43,7 @@ prod__basic_submission:
   variables:
     BDCAT_STAGE: prod
   script:
-    - /venv/bin/python test/test_basic_submission.py
+    - timeout -s SIGINT 115m /venv/bin/python test/test_basic_submission.py
   except:
     - master
     - staging

--- a/test/test_basic_submission.py
+++ b/test/test_basic_submission.py
@@ -286,4 +286,4 @@ class TestGen3DataAccess(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main(verbosity=2)

--- a/test/test_basic_submission.py
+++ b/test/test_basic_submission.py
@@ -143,7 +143,7 @@ class TestGen3DataAccess(unittest.TestCase):
                     log_duration(table, time.time() - start)
                     raise RuntimeError('The md5sum workflow run timed out.  '
                                        f'Expected 4 minutes, but took longer than '
-                                       f'{float(start - now) / 60.0} minutes.')
+                                       f'{float(now - start) / 60.0} minutes.')
 
         log_duration(table, time.time() - start)
         with self.subTest('Dockstore Workflow Run Completed Successfully'):


### PR DESCRIPTION
Sending a SIGINT gives a nice stack trace which is preferred  to the previous, opaque output.