### PR TITLE
Set exit status based on test success (fixes #89)

### DIFF
--- a/test/test_basic_submission.py
+++ b/test/test_basic_submission.py
@@ -341,3 +341,4 @@ if __name__ == "__main__":
             client.log_test_results(test_name, status, timestamp, create=False)
         except Exception as e:
             logger.exception('Failed to log test %r', test, exc_info=e)
+    sys.exit(not results.wasSuccessful())


### PR DESCRIPTION
In order to report tests results, we prevented unittest.main from exiting with `exit=False`. This also prevented failure from causing a bad status code. The fix is simple to reproduce the exit code from unittest.main().